### PR TITLE
Corrected the icon converter of the templates; fixes #29

### DIFF
--- a/DEHPCommon/UserInterfaces/Views/ObjectBrowser/ObjectBrowserDataTemplates.xaml
+++ b/DEHPCommon/UserInterfaces/Views/ObjectBrowser/ObjectBrowserDataTemplates.xaml
@@ -7,7 +7,7 @@
                     xmlns:commonData="clr-namespace:CDP4Common.CommonData;assembly=CDP4Common"
                     xmlns:viewModels="clr-namespace:DEHPCommon.UserInterfaces.ViewModels">
 
-    <converters:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
+    <converters:ElementDefinitionBrowserIconConverter x:Key="ThingToIconUriConverter" />
 
     <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <converters:EnumerationValueDefinitionConverter x:Key="EnumerationValueDefinitionConverter" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-Common/pulls) open
- [x] I have verified that I am following theDEHP-Common [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-Common/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
fixes #29 
The DataTemplates were using the wrong icon converter. Corrected it.

<!-- Thanks for contributing to DEHP-Common! -->