### PR TITLE
adapter version in exchange history; fixes #70

### DIFF
--- a/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
+++ b/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
@@ -71,7 +71,7 @@ namespace DEHPCommon.Tests.Services
 
             this.service = new ExchangeHistoryService(this.hubController.Object, this.statusBar.Object);
 
-            this.element = new ElementDefinition();
+            this.element = new ElementDefinition() {Name = "element", ShortName = "el"};
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace DEHPCommon.Tests.Services
             this.element.Parameter.Add(parameter);
             var clone = parameter.Clone(true);
             clone.ValueSet.First().Computed = new ValueArray<string>(new List<string>() { "false", "true", "true", "false" });
-
+            
             Assert.DoesNotThrow(() => this.service.Append(parameter.ValueSet.First(), clone.ValueSet.First()));
             Assert.IsTrue(this.service.PendingEntries.LastOrDefault()?.Message.Contains(parameter.ModelCode()));
             
@@ -130,7 +130,7 @@ namespace DEHPCommon.Tests.Services
 
             var sampledParameter = new Parameter()
             {
-                ParameterType = sampledParameterType, Scale = measurementScale,
+                ParameterType = sampledParameterType, Scale = measurementScale, IsOptionDependent = false,
                 ValueSet =
                 {
                     new ParameterValueSet()
@@ -141,8 +141,8 @@ namespace DEHPCommon.Tests.Services
                         Published = new ValueArray<string>(new List<string>() {"-", "-"}),
                     }
                 }
-
             };
+
             this.element.Parameter.Add(sampledParameter);
 
             var sampledClone = sampledParameter.Clone(true);
@@ -150,6 +150,35 @@ namespace DEHPCommon.Tests.Services
 
             Assert.DoesNotThrow(() => this.service.Append(sampledParameter.ValueSet.First(), sampledClone.ValueSet.First()));
             Assert.IsTrue(this.service.PendingEntries.LastOrDefault()?.Message.Contains(parameter.ModelCode()));
+
+            var parameterOverride = new ParameterOverride()
+            {
+                Parameter = sampledParameter,
+                ValueSet =
+                {
+                    new ParameterOverrideValueSet()
+                    {
+                        ParameterValueSet = sampledParameter.ValueSet.FirstOrDefault(),
+                        Computed = new ValueArray<string>(new List<string>() {"-", "-"}),
+                        Manual = new ValueArray<string>(new List<string>() {"-", "-"}),
+                        Reference = new ValueArray<string>(new List<string>() {"-", "-"}),
+                        Published = new ValueArray<string>(new List<string>() {"-", "-"}),
+                    }
+                }
+            };
+
+            var elementUsage = new ElementUsage()
+            {
+                ParameterOverride = { parameterOverride}
+            };
+
+            this.element.ContainedElement.Add(elementUsage);
+
+            var parameterOverrideclone = parameterOverride.Clone(true);
+            parameterOverride.ValueSet.First().Computed = new ValueArray<string>(new List<string>() { "false", "true", "true", "false" });
+
+            Assert.DoesNotThrow(() => this.service.Append(parameterOverride.ValueSet.First(), parameterOverrideclone.ValueSet.First()));
+            Assert.IsTrue(this.service.PendingEntries.LastOrDefault()?.Message.Contains(parameterOverride.ModelCode()));
         }
 
         [Test]

--- a/DEHPCommon.Tests/UserInterfaces/ViewModels/Rows/ElementDefinitionTreeRows/ParameterSubscriptionRowViewModelTestFixture.cs
+++ b/DEHPCommon.Tests/UserInterfaces/ViewModels/Rows/ElementDefinitionTreeRows/ParameterSubscriptionRowViewModelTestFixture.cs
@@ -57,7 +57,6 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeR
         private Participant participant;
         private Person person;
         private DomainOfExpertise activeDomain;
-        private DomainOfExpertise someotherDomain;
         private EngineeringModel model;
         private EngineeringModelSetup modelsetup;
         private QuantityKind qqParamType;
@@ -90,8 +89,7 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeR
         private ParameterValueSet valueset4;
 
         private Assembler assembler;
-
-
+        
         [SetUp]
         public void Setup()
         {
@@ -162,7 +160,6 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeR
             });
 
             this.activeDomain = new DomainOfExpertise(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "active", ShortName = "active" };
-            this.someotherDomain = new DomainOfExpertise(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "other", ShortName = "other" };
 
             this.parameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri)
             {

--- a/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
+++ b/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
@@ -29,6 +29,7 @@ namespace DEHPCommon.Services.ExchangeHistory
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Text;
     using System.Threading.Tasks;
 
@@ -95,7 +96,7 @@ namespace DEHPCommon.Services.ExchangeHistory
         /// <param name="newValue">The <see cref="IValueSet"/> of reference</param>
         public void Append(ParameterValueSetBase valueToUpdate, IValueSet newValue)
         {
-            var parameter = valueToUpdate.GetContainerOfType<Parameter>();
+            var parameter = valueToUpdate.GetContainerOfType<ParameterOrOverrideBase>();
             var scale = parameter.Scale is null ? "-" : parameter.Scale.ShortName;
 
             var prefix = $"{(valueToUpdate.ActualOption is null ? string.Empty : $" Option: {valueToUpdate.ActualOption.Name}")}" +
@@ -196,6 +197,7 @@ namespace DEHPCommon.Services.ExchangeHistory
 
                 var timestamp = DateTime.Now;
                 this.PendingEntries.ForEach(x => x.Timestamp = timestamp);
+                this.PendingEntries.ForEach(x => x.AdapterVersion = Assembly.GetEntryAssembly()?.GetName().Version);
 
                 var entries = this.Read() ?? new List<ExchangeHistoryEntryViewModel>();
 

--- a/DEHPCommon/UserInterfaces/ViewModels/ExchangeHistory/ExchangeHistoryEntryViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/ExchangeHistory/ExchangeHistoryEntryViewModel.cs
@@ -94,5 +94,21 @@ namespace DEHPCommon.UserInterfaces.ViewModels.ExchangeHistory
             get => this.timestamp;
             set => this.RaiseAndSetIfChanged(ref this.timestamp, value);
         }
+
+        /// <summary>
+        /// Backing field for <see cref="AdapterVersion"/>
+        /// </summary>
+        private Version adapterVersion;
+
+        /// <summary>
+        /// Gets or sets the dst adapter version
+        /// </summary>
+        [JsonProperty]
+
+        public Version AdapterVersion
+        {
+            get => this.adapterVersion;
+            set => this.RaiseAndSetIfChanged(ref this.adapterVersion, value);
+        }
     }
 }

--- a/DEHPCommon/UserInterfaces/ViewModels/LoginViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/LoginViewModel.cs
@@ -358,7 +358,7 @@ namespace DEHPCommon.UserInterfaces.ViewModels
         /// <returns>The <see cref="Task"/></returns>
         private async Task ExecuteLogin()
         {
-            this.LogMessage = "Loggin in...";
+            this.LogMessage = "Login in...";
             this.LoginSuccessful = false;
             this.LoginFailed = false;
 
@@ -367,13 +367,13 @@ namespace DEHPCommon.UserInterfaces.ViewModels
                 var credentials = new Credentials(this.UserName, this.Password, new Uri(this.Uri));
                 this.LoginSuccessful = await this.hubController.Open(credentials, this.SelectedServerType.Key);
                 this.PopulateEngineeringModels();
-                this.LogMessage = "Loggin successful";
+                this.LogMessage = "Login successful";
             }
             catch (Exception exception)
             {
                 this.LoginFailed = true;
-                this.logger.Error($"Loggin failed: {exception}");
-                this.LogMessage = $"Loggin failed: {exception.Message}";
+                this.logger.Error($"Login failed: {exception}");
+                this.LogMessage = $"Login failed: {exception.Message}";
             }
         }
 

--- a/DEHPCommon/UserInterfaces/ViewModels/Rows/ElementDefinitionTreeRows/ParameterValueRowViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/Rows/ElementDefinitionTreeRows/ParameterValueRowViewModel.cs
@@ -79,11 +79,6 @@ namespace DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows
         private string modelCode;
 
         /// <summary>
-        /// Backing field for <see cref="Formula"/>
-        /// </summary>
-        private string formula;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ParameterValueRowViewModel"/> class
         /// </summary>
         /// <param name="parameterBase">
@@ -146,16 +141,7 @@ namespace DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows
         /// Gets the <see cref="ClassKind"/> of the <see cref="ParameterType"/> represented by this <see cref="IValueSetRow"/>
         /// </summary>
         public ClassKind ParameterTypeClassKind { get; protected set; }
-
-        /// <summary>
-        /// Gets or sets the Formula column value
-        /// </summary>
-        public string Formula
-        {
-            get => this.formula;
-            set => this.RaiseAndSetIfChanged(ref this.formula, value);
-        }
-
+        
         /// <summary>
         /// Set the Values of this row
         /// </summary>

--- a/DEHPCommon/UserInterfaces/Views/ExchangeHistory.xaml
+++ b/DEHPCommon/UserInterfaces/Views/ExchangeHistory.xaml
@@ -42,6 +42,7 @@
                     <dxg:GridColumn AllowEditing="False" FieldName="Person" />
                     <dxg:GridColumn AllowEditing="False" FieldName="Domain" />
                     <dxg:GridColumn AllowEditing="False" FieldName="Message" Width="*"/>
+                    <dxg:GridColumn AllowEditing="False" FieldName="AdapterVersion" />
                 </dxg:GridControl.Columns>
 
             </dxg:GridControl>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-Common/pulls) open
- [x] I have verified that I am following the DEH-Common [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-Common/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
fixes #53  fixes [#70](https://github.com/RHEAGROUP/DEH-ECOSIMPRO/issues/70)

- [x] The LocalExchangeHistory tags entries with the adapter version
- [x] Loggin => login
- [x] Fix the LocalExchangeHistory so it supports ParameterOverride
- [x] Sonarcloud issue [use new if hidding was intended](https://sonarcloud.io/project/issues?id=RHEAGROUP_DEHP-Common&issues=AXeLGw8N_aSYWqzWFMxp&open=AXeLGw8N_aSYWqzWFMxp)

<!-- Thanks for contributing to DEHP-Common! -->