### PR TITLE
decoupling things to tranfer; fixes #57

### DIFF
--- a/DEHPCommon.Tests/UserInterfaces/ViewModels/ElementDefinitionBrowserViewModelTestFixture.cs
+++ b/DEHPCommon.Tests/UserInterfaces/ViewModels/ElementDefinitionBrowserViewModelTestFixture.cs
@@ -47,6 +47,7 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels
 
     using DEHPCommon.Events;
     using DEHPCommon.UserInterfaces.ViewModels;
+    using DEHPCommon.UserInterfaces.ViewModels.Rows;
     using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
 
     using DevExpress.Xpf.Docking.Platform;
@@ -175,6 +176,48 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels
             vm.CollapseAllRows();
             Assert.IsFalse(vm.IsExpanded);
             Assert.IsFalse(vm.ContainedRows.FirstOrDefault()?.IsExpanded);
+        }
+
+        [Test]
+        public void VerifyRowSelectionForTransfer()
+        {
+            this.iteration.Element.Add(this.elementDef);
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object);
+            var elementRow = vm.ContainedRows.FirstOrDefault() as RowViewModelBase<ElementDefinition>;
+            Assert.IsNotNull(elementRow);
+            Assert.IsFalse(elementRow.IsSelectedForTransfer);
+            CDPMessageBus.Current.SendMessage(new SelectEvent(elementRow.Thing));
+            Assert.IsFalse(elementRow.IsSelectedForTransfer);
+            var clone = this.elementDef.Clone(false);
+            clone.Iid = Guid.Empty;
+            CDPMessageBus.Current.SendMessage(new SelectEvent(clone));
+            Assert.IsFalse(elementRow.IsSelectedForTransfer);
+
+            clone.Iid = this.elementDef.Iid;
+            clone.ShortName = "newShortName";
+            CDPMessageBus.Current.SendMessage(new SelectEvent(clone));
+            Assert.IsFalse(elementRow.IsSelectedForTransfer);
+
+            this.iteration.Element.Clear();
+            clone = this.elementDef.Clone(false);
+            this.iteration.Element.Add(clone);
+            this.elementDef.Iid = Guid.Empty;
+            this.iteration.Element.Add(this.elementDef);
+
+            vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object);
+            elementRow = vm.ContainedRows.FirstOrDefault() as RowViewModelBase<ElementDefinition>;
+            Assert.IsNotNull(elementRow);
+            CDPMessageBus.Current.SendMessage(new SelectEvent(elementRow.Thing));
+            Assert.IsTrue(elementRow.IsSelectedForTransfer);
+            Assert.AreEqual(2, vm.ContainedRows.Count);
+            var elementRow2 = vm.ContainedRows.LastOrDefault() as RowViewModelBase<ElementDefinition>;
+            Assert.IsNotNull(elementRow2);
+
+            CDPMessageBus.Current.SendMessage(new SelectEvent(elementRow2.Thing));
+            Assert.IsTrue(elementRow2.IsSelectedForTransfer);
+
+            CDPMessageBus.Current.SendMessage(new SelectEvent(elementRow.Thing, true));
+            Assert.IsFalse(elementRow.IsSelectedForTransfer);
         }
 
         [Test]

--- a/DEHPCommon.Tests/UserInterfaces/ViewModels/ObjectBrowserViewModelTestFixture.cs
+++ b/DEHPCommon.Tests/UserInterfaces/ViewModels/ObjectBrowserViewModelTestFixture.cs
@@ -27,6 +27,7 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reactive.Concurrency;
     using System.Threading.Tasks;
 
@@ -146,6 +147,14 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels
             this.viewModel.BuildTrees();
             Assert.IsNotEmpty(this.viewModel.Things);
             Assert.AreEqual(1, this.viewModel.Things.Count);
+            Assert.AreEqual(4, this.viewModel.Things.First().ContainedRows.Count);
+
+            this.viewModel.Things.Clear();
+            var iterationClone = this.iteration.Clone(false);
+            iterationClone.Element.Clear();
+            this.viewModel.BuildTrees(iterationClone);
+            Assert.IsNotEmpty(this.viewModel.Things);
+            Assert.AreEqual(1, this.viewModel.Things.Count);Assert.IsEmpty(this.viewModel.Things.First().ContainedRows);
         }
 
         [Test]

--- a/DEHPCommon.Tests/UserInterfaces/ViewModels/Rows/ElementDefinitionTreeRows/ElementDefinitionRowViewModelsTestFixture.cs
+++ b/DEHPCommon.Tests/UserInterfaces/ViewModels/Rows/ElementDefinitionTreeRows/ElementDefinitionRowViewModelsTestFixture.cs
@@ -524,5 +524,12 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeR
             Assert.DoesNotThrow(() => vm.UpdateThing(newElementDefinition));
             Assert.AreSame(vm.Thing, newElementDefinition);
         }
+
+        [Test]
+        public void VerifyDispose()
+        {
+            var vm = new ElementDefinitionRowViewModel(this.elementDefinition, this.activeDomain, this.session.Object, null);
+            Assert.DoesNotThrow(() => vm.Dispose());
+        }
     }
 }

--- a/DEHPCommon.Tests/UserInterfaces/ViewModels/TransferControlViewModelTestFixture.cs
+++ b/DEHPCommon.Tests/UserInterfaces/ViewModels/TransferControlViewModelTestFixture.cs
@@ -47,6 +47,23 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels
             Assert.IsNull(vm.TransferCommand);
             Assert.IsNull(vm.CancelCommand);
             Assert.Zero(vm.Progress);
+            Assert.Zero(vm.NumberOfThing);
+            Assert.IsNotNull(vm.TransferButtonText);
+        }
+
+        [Test]
+        public void VerifyTransferButtonText()
+        {
+            var vm = new TestTransferControlViewModel();
+
+            const string transferText = "Transfer";
+            Assert.AreEqual(transferText, vm.TransferButtonText);
+            vm.NumberOfThing = 1;
+            Assert.AreEqual("Transfer 1 thing", vm.TransferButtonText);
+            vm.NumberOfThing = 42;
+            Assert.AreEqual("Transfer 42 things", vm.TransferButtonText);
+            vm.NumberOfThing = 0;
+            Assert.AreEqual(transferText, vm.TransferButtonText);
         }
     }
 }

--- a/DEHPCommon/Events/SelectEvent.cs
+++ b/DEHPCommon/Events/SelectEvent.cs
@@ -1,0 +1,57 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SelectEvent.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2020 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHP Common Library
+// 
+//    The DEHPCommon is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPCommon is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPCommon.Events
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// The purpose of the <see cref="SelectEvent"/> is to notify an observer
+    /// that the referenced <see cref="ElementBase"/> has to be selected.
+    /// </summary>
+    public class SelectEvent
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SelectEvent"/> class.
+        /// </summary>
+        /// <param name="thing"> The payload <see cref="ElementBase"/> to highlight. </param>
+        /// <param name="cancelSelection"> A value indicating whether the listener has to cancel selection </param>
+        public SelectEvent(ElementBase thing, bool cancelSelection = false) 
+        {
+            this.SelectedThing = thing;
+            this.CancelSelection = cancelSelection;
+        }
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="ElementBase"/>
+        /// </summary>
+        public ElementBase SelectedThing { get; set; }
+
+        /// <summary>
+        /// Gets or sets value indicating whether the <see cref="SelectedThing"/> should be unselected
+        /// </summary>
+        public bool CancelSelection { get; set; }
+    }
+}

--- a/DEHPCommon/Services/GridUpdateService.cs
+++ b/DEHPCommon/Services/GridUpdateService.cs
@@ -36,7 +36,7 @@ namespace DEHPCommon.Services
     /// The service used to lock the update of a grid view when update in the view-model are occuring
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class GridUpdateService
+    public static class GridUpdateService
     {
         /// <summary>
         /// The current logger
@@ -109,6 +109,6 @@ namespace DEHPCommon.Services
             {
                 Logger.Error(exception, $"A problem occurend when UpdateStartedPropertyChanged was called");
             }
-}
+        }
     }
 }

--- a/DEHPCommon/Services/GridUpdateService.cs
+++ b/DEHPCommon/Services/GridUpdateService.cs
@@ -1,0 +1,114 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GridUpdateService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHP Common Library
+// 
+//    The DEHPCommon is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPCommon is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPCommon.Services
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Windows;
+
+    using DevExpress.Xpf.Grid;
+
+    using NLog;
+
+    /// <summary>
+    /// The service used to lock the update of a grid view when update in the view-model are occuring
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class GridUpdateService
+    {
+        /// <summary>
+        /// The current logger
+        /// </summary>
+        private static Logger Logger = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// The <see cref="DependencyProperty"/> used to lock the update in a grid
+        /// </summary>
+        public static readonly DependencyProperty UpdateStartedProperty = DependencyProperty.RegisterAttached("UpdateStarted", typeof(bool?), typeof(GridUpdateService), new FrameworkPropertyMetadata(false, UpdateStartedPropertyChanged));
+
+        /// <summary>
+        /// Sets the <see cref="UpdateStartedProperty"/> property
+        /// </summary>
+        /// <param name="element">The <see cref="UIElement"/> where the value is set</param>
+        /// <param name="value">The <see cref="bool"/> value</param>
+        public static void SetUpdateStarted(UIElement element, bool? value)
+        {
+            try
+            {
+                element.SetValue(UpdateStartedProperty, value);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception, $"A problem occurend when SetUpdateStarted was called");
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="UpdateStartedProperty"/> property
+        /// </summary>
+        /// <param name="element">The <see cref="UIElement"/> where the value is used</param>
+        /// <returns>A value indicating whether an update is occuring or not</returns>
+        public static bool? GetUpdateStarted(UIElement element)
+        {
+            return (bool?)element.GetValue(UpdateStartedProperty);
+        }
+
+        /// <summary>
+        /// The <see cref="DependencyPropertyChangedEventArgs"/> event-handler for the <see cref="UpdateStartedProperty"/> property
+        /// </summary>
+        /// <param name="source">The grid which visual and internal update should be prevented</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/></param>
+        private static void UpdateStartedPropertyChanged(DependencyObject source, DependencyPropertyChangedEventArgs e)
+        {
+            if (!(source is GridDataControlBase grid))
+            {
+                throw new InvalidOperationException("The Service can only be used on GridDataControlBase view elements such as GridControl or TreeListControl.");
+            }
+
+            try
+            {
+                switch (e.NewValue)
+                {
+                    case true:
+                        grid.BeginDataUpdate();
+                        break;
+                    case false when grid is TreeListControl treeListControl:
+                        treeListControl.View.CancelRowEdit();
+                        treeListControl.EndDataUpdate();
+                        break;
+                    case false when grid is GridControl gridControl && gridControl.DataController.IsUpdateLocked:
+                        // cancel out of any active edit.
+                        gridControl.View.CancelRowEdit();
+                        grid.EndDataUpdate();
+                        break;
+                }
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception, $"A problem occurend when UpdateStartedPropertyChanged was called");
+            }
+}
+    }
+}

--- a/DEHPCommon/UserInterfaces/ViewModels/BrowserViewModelBase.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/BrowserViewModelBase.cs
@@ -228,6 +228,11 @@ namespace DEHPCommon.UserInterfaces.ViewModels
                 {
                     this.Logger.Trace("The Disposables collection of the {0} is null", this.GetType().Name);
                 }
+
+                foreach (var row in this.ContainedRows)
+                {
+                    row.Dispose();
+                }
             }
 
             // Indicate that the instance has been disposed.

--- a/DEHPCommon/UserInterfaces/ViewModels/ElementDefinitionsBrowserViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/ElementDefinitionsBrowserViewModel.cs
@@ -28,9 +28,7 @@ namespace DEHPCommon.UserInterfaces.ViewModels
     using System.Collections.Generic;
     using System.Linq;
     using System.Reactive.Linq;
-    using System.Threading.Tasks;
     using System.Windows;
-    using System.Windows.Input;
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
@@ -38,15 +36,12 @@ namespace DEHPCommon.UserInterfaces.ViewModels
 
     using CDP4Dal;
     using CDP4Dal.Events;
-    using CDP4Dal.Operations;
     using CDP4Dal.Permission;
 
     using DEHPCommon.Enumerators;
     using DEHPCommon.Events;
     using DEHPCommon.Extensions;
-    using DEHPCommon.Mvvm;
     using DEHPCommon.UserInterfaces.ViewModels.Comparers;
-    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
     using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
 
     using ReactiveUI;
@@ -408,13 +403,8 @@ namespace DEHPCommon.UserInterfaces.ViewModels
         /// <param name="elementDef">The <see cref="ElementDefinition"/> to add</param>
         private void AddElementDefinitionRow(ElementDefinition elementDef)
         {
-            this.Session.OpenIterations.TryGetValue(this.Thing, out var tuple);
-
-            if (tuple != null)
-            {
-                var row = new ElementDefinitionRowViewModel(elementDef, tuple.Item1, this.Session, this);
-                this.ContainedRows.SortedInsert(row, RowComparer);
-            }
+            var row = new ElementDefinitionRowViewModel(elementDef, this.QueryCurrentDomainOfExpertise(), this.Session, this);
+            this.ContainedRows.SortedInsert(row, RowComparer);
         }
 
         /// <summary>

--- a/DEHPCommon/UserInterfaces/ViewModels/Interfaces/IObjectBrowserViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/Interfaces/IObjectBrowserViewModel.cs
@@ -26,6 +26,8 @@ namespace DEHPCommon.UserInterfaces.ViewModels.Interfaces
 {
     using System;
 
+    using CDP4Common.EngineeringModelData;
+
     using DEHPCommon.Services.ObjectBrowserTreeSelectorService;
 
     using ReactiveUI;
@@ -95,7 +97,8 @@ namespace DEHPCommon.UserInterfaces.ViewModels.Interfaces
         /// <summary>
         /// Adds to the <see cref="ObjectBrowserBaseViewModel.Things"/> collection the specified by <see cref="IObjectBrowserTreeSelectorService"/> trees
         /// </summary>
-        void BuildTrees();
+        /// <param name="iteration">An optional <see cref="Iteration"/> to use for generation of the trees</param>
+        void BuildTrees(Iteration iteration = null);
 
         /// <summary>
         /// Populate the context menu for the implementing view model

--- a/DEHPCommon/UserInterfaces/ViewModels/NetChangePreview/NetChangePreviewViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/NetChangePreview/NetChangePreviewViewModel.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NetChangePreviewViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2020-2021 RHEA System S.A.
 // 
@@ -39,9 +39,14 @@ namespace DEHPCommon.UserInterfaces.ViewModels.NetChangePreview
     public abstract class NetChangePreviewViewModel : ObjectBrowserBaseViewModel, INetChangePreviewViewModel
     {
         /// <summary>
-        /// Gets the collection of <see cref="Thing"/>s at their previous state
+        /// Gets the collection of <see cref="Thing"/>s at their previous state, this property is used for updating the Net change preview based on a selection
         /// </summary>
         protected ReactiveList<Thing> ThingsAtPreviousState { get; } = new ReactiveList<Thing>();
+
+        /// <summary>
+        /// Gets the collection of <see cref="Thing"/>s to be actually transfered
+        /// </summary>
+        protected ReactiveList<object> SelectedThingsToTransfer { get; } = new ReactiveList<object>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NetChangePreviewViewModel"/> class.

--- a/DEHPCommon/UserInterfaces/ViewModels/ObjectBrowserBaseViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/ObjectBrowserBaseViewModel.cs
@@ -178,14 +178,15 @@ namespace DEHPCommon.UserInterfaces.ViewModels
         /// <summary>
         /// Adds to the <see cref="Things"/> collection the specified by <see cref="IObjectBrowserTreeSelectorService"/> trees
         /// </summary>
-        public virtual void BuildTrees()
+        /// <param name="iteration">An optional <see cref="Iteration"/> to use for generation of the trees</param>
+        public virtual void BuildTrees(Iteration iteration = null)
         {
             foreach (var thingKind in this.objectBrowserTreeSelectorService.ThingKinds)
             {
                 if (thingKind == typeof(ElementDefinition) &&
                     this.Things.OfType<IBrowserViewModelBase<Thing>>().All(x => x.Thing.Iid != this.HubController.OpenIteration.Iid))
                 {
-                    this.Things.Add(new ElementDefinitionsBrowserViewModel(this.HubController.OpenIteration, this.HubController.Session));
+                    this.Things.Add(new ElementDefinitionsBrowserViewModel(iteration ?? this.HubController.OpenIteration, this.HubController.Session));
                 }
             }
         }

--- a/DEHPCommon/UserInterfaces/ViewModels/Rows/ElementDefinitionTreeRows/ElementBaseRowViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/Rows/ElementDefinitionTreeRows/ElementBaseRowViewModel.cs
@@ -37,6 +37,7 @@ namespace DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows
     using CDP4Dal;
     using CDP4Dal.Events;
 
+    using DEHPCommon.Events;
     using DEHPCommon.Extensions;
     using DEHPCommon.UserInterfaces.ViewModels.Comparers;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
@@ -288,6 +289,13 @@ namespace DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows
         protected override void InitializeSubscriptions()
         {
             base.InitializeSubscriptions();
+
+            var selectSubscription = CDPMessageBus.Current.Listen<SelectEvent>()
+                .Where(x => x.SelectedThing.ShortName == this.Thing.ShortName && x.SelectedThing.Iid == this.Thing.Iid && (this.Thing.Original != null || this.Thing.Iid == Guid.Empty))
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(x => this.IsSelectedForTransfer = !x.CancelSelection);
+
+            this.Disposables.Add(selectSubscription);
 
             var ownerListener = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.Thing.Owner)
                                    .Where(objectChange => objectChange.EventKind == EventKind.Updated)

--- a/DEHPCommon/UserInterfaces/ViewModels/Rows/RowViewModelBase.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/Rows/RowViewModelBase.cs
@@ -65,6 +65,11 @@ namespace DEHPCommon.UserInterfaces.ViewModels.Rows
         private bool isHighlighted;
 
         /// <summary>
+        /// Backing property for the <see cref="IsSelectedForTransfer"/>
+        /// </summary>
+        private bool isSelectedForTransfer;
+
+        /// <summary>
         /// Backing field for <see cref="RowStatus"/>
         /// </summary>
         private RowStatusKind rowStatus;
@@ -163,6 +168,15 @@ namespace DEHPCommon.UserInterfaces.ViewModels.Rows
         {
             get => this.isHighlighted;
             set => this.RaiseAndSetIfChanged(ref this.isHighlighted, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the row is highlighted
+        /// </summary>
+        public bool IsSelectedForTransfer
+        {
+            get => this.isSelectedForTransfer;
+            set => this.RaiseAndSetIfChanged(ref this.isSelectedForTransfer, value);
         }
 
         /// <summary>

--- a/DEHPCommon/UserInterfaces/ViewModels/TransferControlViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/TransferControlViewModel.cs
@@ -24,6 +24,7 @@
 
 namespace DEHPCommon.UserInterfaces.ViewModels
 {
+    using System;
     using System.Reactive;
     using System.Windows.Input;
 
@@ -62,6 +63,49 @@ namespace DEHPCommon.UserInterfaces.ViewModels
         {
             get => this.progress;
             set => this.RaiseAndSetIfChanged(ref this.progress, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="NumberOfThing"/>
+        /// </summary>
+        private int numberOfThing;
+
+        /// <summary>
+        /// Gets or sets the current number of item that will be transfered
+        /// </summary>
+        public int NumberOfThing
+        {
+            get => this.numberOfThing;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.numberOfThing, value);
+
+                switch (this.numberOfThing)
+                {
+                    case > 0:
+                        var thereIsMoreThanOneThing = this.numberOfThing > 1 ? "s" : string.Empty;
+                        this.TransferButtonText = $"Transfer {this.NumberOfThing} thing{thereIsMoreThanOneThing}";
+                        break;
+
+                    default:
+                        this.TransferButtonText = "Transfer";
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="TransferButtonText"/>
+        /// </summary>
+        private string transferButtonText = "Transfer";
+
+        /// <summary>
+        /// Gets or sets the current number of item that will be transfered
+        /// </summary>
+        public string TransferButtonText
+        {
+            get => this.transferButtonText;
+            set => this.RaiseAndSetIfChanged(ref this.transferButtonText, value);
         }
         
         /// <summary>

--- a/DEHPCommon/UserInterfaces/Views/ObjectBrowser/ObjectBrowser.xaml
+++ b/DEHPCommon/UserInterfaces/Views/ObjectBrowser/ObjectBrowser.xaml
@@ -12,6 +12,7 @@
              xmlns:viewModels="clr-namespace:DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows"
              xmlns:converters="clr-namespace:DEHPCommon.Converters"
              xmlns:behaviors="clr-namespace:DEHPCommon.UserInterfaces.Behaviors"
+             xmlns:services="clr-namespace:DEHPCommon.Services"
              MinWidth="400" d:DesignWidth="400" mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -29,10 +30,14 @@
                          BorderEffect="Default"
                          BorderEffectColor="Blue">
         <Grid>
+
             <dxg:TreeListControl ItemsSource="{Binding Things}"
                                  SelectedItem="{Binding SelectedThing}"
                                  SelectedItems="{Binding SelectedThings}"
-                                 SelectionMode="MultipleRow">
+                                 SelectionMode="MultipleRow"
+                                 services:GridUpdateService.UpdateStarted="{Binding IsBusy,
+                                                                            Mode=OneWay,
+                                                                            UpdateSourceTrigger=PropertyChanged}">
                 <dxmvvm:Interaction.Behaviors>
                     <behaviors:ContextMenuBehavior/>
                 </dxmvvm:Interaction.Behaviors>
@@ -63,6 +68,9 @@
                                     <DataTrigger Binding="{Binding Path=Row.IsHighlighted}" Value="True">
                                         <Setter Property="Background" Value="Yellow"/>
                                     </DataTrigger>
+                                    <DataTrigger Binding="{Binding Path=Row.IsSelectedForTransfer}" Value="True">
+                                        <Setter Property="Background" Value="LightGreen"/>
+                                    </DataTrigger>
                                     <DataTrigger Binding="{Binding Row.IsDefault, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
                                         <Setter Property="FontWeight" Value="Bold" />
                                     </DataTrigger>
@@ -73,9 +81,6 @@
                                 <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
                             </Style>
                         </dxg:TreeListView.RowStyle>
-                        <dxg:TreeListView.FocusedRow>
-                            <dynamic:ExpandoObject />
-                        </dxg:TreeListView.FocusedRow>
                         <dxg:TreeListView.ContextMenu>
                             <ContextMenu />
                         </dxg:TreeListView.ContextMenu>

--- a/DEHPCommon/UserInterfaces/Views/TransferControl.xaml
+++ b/DEHPCommon/UserInterfaces/Views/TransferControl.xaml
@@ -3,11 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:converters="clr-namespace:DEHPCommon.Converters"
+             xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
              mc:Ignorable="d" d:DesignHeight="100" d:DesignWidth="650">
     <UserControl.Resources>
         <ResourceDictionary>
-            <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <dxmvvm:NumericToVisibilityConverter x:Key="NumericToVisibilityConverter"/> 
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -21,10 +21,12 @@
         </Grid.ColumnDefinitions>
         <Grid Grid.Row="0" Grid.ColumnSpan="2" Margin="10,10,10,5" HorizontalAlignment="Stretch">
             <ProgressBar Background="AliceBlue" Height="40" Foreground="DarkGray" Maximum="100" Minimum="0" IsIndeterminate="{Binding IsIndeterminate}" Value="{Binding Progress}" />
-            <TextBlock HorizontalAlignment="Center" Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}}" VerticalAlignment="Center" FontSize="18" Text="{Binding Progress, StringFormat={}{0}%}" />
+            <TextBlock HorizontalAlignment="Center" Visibility="{Binding Progress, Converter={StaticResource NumericToVisibilityConverter}}"  VerticalAlignment="Center" FontSize="18" Text="{Binding Progress, StringFormat={}{0}%}" />
         </Grid>
         <Button ToolTip="Attempt to cancel the transfers" Grid.Row="1" Grid.Column="0" Height="40" Margin="10,5,5,10" Content="Cancel" Command="{Binding CancelCommand}"/>
-        <Button ToolTip="Transfer all mapped things from dst to hub &#x0a;and mapped things from hub to dst &#x0a; Mapping will also be persisted"
-                Grid.Row="1" Grid.Column="1" Height="40" Margin="5,5,10,10" Content="Transfer" Command="{Binding TransferCommand}"/>
+        <Button ToolTip="Transfer selected mapped things from dst to hub &#x0a;and mapped things from hub to dst &#x0a; Mapping will also be persisted"
+                Grid.Row="1" Grid.Column="1" Height="40" Margin="5,5,10,10" Command="{Binding TransferCommand}">
+            <TextBlock HorizontalAlignment="Center" Text="{Binding TransferButtonText}"/>
+        </Button>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-Common/pulls) open
- [x] I have verified that I am following theDEHP-Common [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-Common/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
fixes #57
- [x] Make the necessary changes that enables dst adapters to transfer user selected things
- [x] Add the number of things to transfer in the Transfer button
- [x] Added the GridUpdateService to improve performances
- [x] Added an overload to the BuildTrees method of ObjectBrowsers to allow building on specified Iteration
- [x] BrowserViewModels dispose of their Contained rows on Dispose
<!-- Thanks for contributing to DEHP-Common! -->