### PR TITLE
Support for multiple values valueset by the ExchangeHistory ;fixes #64

### DIFF
--- a/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
+++ b/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
@@ -232,5 +232,37 @@ namespace DEHPCommon.Tests.Services
             this.service.ClearPending();
             Assert.IsEmpty(this.service.PendingEntries);
         }
+
+        [Test]
+        public void VerifyAppendWithMultipleValuesValueSets()
+        {
+            var values = new List<string>() { "-", "-", "-" };
+
+            var valueSet = new ParameterValueSet()
+            {
+                Computed = new ValueArray<string>(values)
+            };
+
+            var valueSetClone = valueSet.Clone(false);
+
+            var compoundParameterType = new CompoundParameterType()
+            {
+                Name = "testParameterType",
+                ShortName = "testParameterType",
+                Component =
+                {
+                    new ParameterTypeComponent() { ParameterType = new DateParameterType() { Name = "date" } },
+                    new ParameterTypeComponent() { ParameterType = new TextParameterType() { Name = "text" } },
+                    new ParameterTypeComponent() { ParameterType = new SimpleQuantityKind() { Name = "number" } }
+                }
+            };
+
+            var parameter = new Parameter() { ParameterType = compoundParameterType, ValueSet = { valueSet }};
+            this.element.Parameter.Add(parameter);
+            
+            Assert.DoesNotThrow(() => this.service.Append(valueSet, valueSetClone));
+
+            Assert.IsTrue(this.service.PendingEntries.LastOrDefault()?.Message.Contains(compoundParameterType.Name));
+        }
     }
 }

--- a/DEHPCommon.Tests/UserInterfaces/ViewModels/ObjectBrowserViewModelTestFixture.cs
+++ b/DEHPCommon.Tests/UserInterfaces/ViewModels/ObjectBrowserViewModelTestFixture.cs
@@ -155,6 +155,7 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels
             this.viewModel.BuildTrees(iterationClone);
             Assert.IsNotEmpty(this.viewModel.Things);
             Assert.AreEqual(1, this.viewModel.Things.Count);Assert.IsEmpty(this.viewModel.Things.First().ContainedRows);
+            Assert.IsTrue(this.viewModel.Things.FirstOrDefault()?.IsExpanded);
         }
 
         [Test]

--- a/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
+++ b/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
@@ -107,9 +107,9 @@ namespace DEHPCommon.Services.ExchangeHistory
 
             var newValueString = $"{prefix} {newValueRepresentation} [{scale}]";
             var valueToUpdateString = $"{prefix} {oldValueRepresentation} [{scale}]";
-
+            
             this.Append($"Value: [{valueToUpdateString}] from Parameter [{parameter?.ModelCode()}] " +
-                                        $"has been updated to [{newValueString}]");
+                        $"has been updated to [{newValueString}]");
         }
 
         /// <summary>
@@ -180,8 +180,8 @@ namespace DEHPCommon.Services.ExchangeHistory
                 var cols = parameter.ParameterType.NumberOfValues;
                 return $"[{valueSet.Computed.Count / cols}x{cols}]";
             }
-
-            return valueSet.Computed[0] ?? "-";
+            
+            return valueSet.Computed.DefaultIfEmpty("-").Aggregate((x, y) => $"{x},{y}");
         }
 
         /// <summary>

--- a/DEHPCommon/UserInterfaces/ViewModels/ObjectBrowserBaseViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/ObjectBrowserBaseViewModel.cs
@@ -189,6 +189,11 @@ namespace DEHPCommon.UserInterfaces.ViewModels
                     this.Things.Add(new ElementDefinitionsBrowserViewModel(iteration ?? this.HubController.OpenIteration, this.HubController.Session));
                 }
             }
+
+            if (this.Things.FirstOrDefault() is { } firstNode)
+            {
+                firstNode.IsExpanded = true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-Common/pulls) open
- [x] I have verified that I am following theDEHP-Common [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-Common/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
fixes #64 
<!-- A description of the changes proposed in the pull-request -->
- [x] Update the ExchangeHistoryService so it supports to log value changes for multiple values valueSet parameters
- [x] Set the first root node of ObjectBrowser tree to unfolded by default
<!-- Thanks for contributing to DEHP-Common! -->