### PR TITLE
Adapter version Service implemented : Fixes #33

### DIFF
--- a/DEHPCommon.Tests/HubController/HubControllerTestFixture.cs
+++ b/DEHPCommon.Tests/HubController/HubControllerTestFixture.cs
@@ -260,8 +260,8 @@ namespace DEHPCommon.Tests.HubController
         {
             Assert.IsFalse(this.hubController.IsSessionOpen);
             Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await this.hubController.Open(new Credentials("admin", "pass", this.uri), (ServerType) 32));
-            Assert.ThrowsAsync<HttpRequestException>(async () => await this.hubController.Open(new Credentials("admin", "pass", this.uri), ServerType.Cdp4WebServices));
-            Assert.ThrowsAsync<HttpRequestException>(async () => await this.hubController.Open(new Credentials("admin", "poss", this.uri), ServerType.OcdtWspServer));
+            Assert.ThrowsAsync<DalReadException>(async () => await this.hubController.Open(new Credentials("admin", "pass", this.uri), ServerType.Cdp4WebServices));
+            Assert.ThrowsAsync<DalReadException>(async () => await this.hubController.Open(new Credentials("admin", "poss", this.uri), ServerType.OcdtWspServer));
             Assert.IsFalse(this.hubController.IsSessionOpen);
         }
 

--- a/DEHPCommon.Tests/HubController/HubControllerTestFixture.cs
+++ b/DEHPCommon.Tests/HubController/HubControllerTestFixture.cs
@@ -260,8 +260,8 @@ namespace DEHPCommon.Tests.HubController
         {
             Assert.IsFalse(this.hubController.IsSessionOpen);
             Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await this.hubController.Open(new Credentials("admin", "pass", this.uri), (ServerType) 32));
-            Assert.ThrowsAsync<DalReadException>(async () => await this.hubController.Open(new Credentials("admin", "pass", this.uri), ServerType.Cdp4WebServices));
-            Assert.ThrowsAsync<DalReadException>(async () => await this.hubController.Open(new Credentials("admin", "poss", this.uri), ServerType.OcdtWspServer));
+            Assert.CatchAsync(async () => await this.hubController.Open(new Credentials("admin", "pass", this.uri), ServerType.Cdp4WebServices));
+            Assert.CatchAsync(async () => await this.hubController.Open(new Credentials("admin", "poss", this.uri), ServerType.OcdtWspServer));
             Assert.IsFalse(this.hubController.IsSessionOpen);
         }
 

--- a/DEHPCommon.Tests/Services/AdapterVersionServiceTestFixture.cs
+++ b/DEHPCommon.Tests/Services/AdapterVersionServiceTestFixture.cs
@@ -1,0 +1,50 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="AdapterVersionServiceTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2022 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHP Common Library
+// 
+//    The DEHPCommon is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPCommon is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPCommon.Tests.Services
+{
+    using System;
+
+    using DEHPCommon.Services.AdapterVersionService;
+
+    using NUnit.Framework;
+
+    public class AdapterVersionServiceTestFixture
+    {
+        private IAdapterVersionService service;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.service = new AdapterVersionService();
+        }
+
+        [Test]
+        public void VerifyProperty()
+        {
+            Assert.IsNull(this.service.CurrentAdapterVersion);
+            Assert.DoesNotThrow(() => this.service.CurrentAdapterVersion = new Version(1,1));
+        }
+    }
+}

--- a/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
+++ b/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
@@ -40,6 +40,7 @@ namespace DEHPCommon.Tests.Services
 
     using DEHPCommon.Enumerators;
     using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.Services.AdapterVersionService;
     using DEHPCommon.Services.ExchangeHistory;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
@@ -50,6 +51,7 @@ namespace DEHPCommon.Tests.Services
     {
         private Mock<IHubController> hubController;
         private Mock<IStatusBarControlViewModel> statusBar;
+        private Mock<IAdapterVersionService> adapterVersionService;
         private ExchangeHistoryService service;
         private DomainOfExpertise domain;
         private Person person;
@@ -69,7 +71,9 @@ namespace DEHPCommon.Tests.Services
 
             this.statusBar = new Mock<IStatusBarControlViewModel>();
 
-            this.service = new ExchangeHistoryService(this.hubController.Object, this.statusBar.Object);
+            this.adapterVersionService = new Mock<IAdapterVersionService>();
+
+            this.service = new ExchangeHistoryService(this.hubController.Object, this.statusBar.Object, this.adapterVersionService.Object);
 
             this.element = new ElementDefinition() {Name = "element", ShortName = "el"};
         }

--- a/DEHPCommon/AppContainer.cs
+++ b/DEHPCommon/AppContainer.cs
@@ -27,6 +27,7 @@ namespace DEHPCommon
     using Autofac;
 
     using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.Services.AdapterVersionService;
     using DEHPCommon.Services.ExchangeHistory;
     using DEHPCommon.Services.FileDialogService;
     using DEHPCommon.Services.IconCacheService;
@@ -65,7 +66,7 @@ namespace DEHPCommon
             containerBuilder.RegisterType<ObjectBrowserTreeSelectorService>().As<IObjectBrowserTreeSelectorService>().SingleInstance();
             containerBuilder.RegisterType<UserPreferenceService<UserPreference>>().As<IUserPreferenceService<UserPreference>>().SingleInstance();
             containerBuilder.RegisterType<ExchangeHistoryService>().As<IExchangeHistoryService>().SingleInstance();
-
+            containerBuilder.RegisterType<AdapterVersionService>().As<IAdapterVersionService>().SingleInstance();
             Container = containerBuilder.Build();
         }
 

--- a/DEHPCommon/Services/AdapterVersionService/AdapterVersionService.cs
+++ b/DEHPCommon/Services/AdapterVersionService/AdapterVersionService.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="AdapterVersionService.cs" company="RHEA System S.A.">
+// Copyright (c) 2020-2022 RHEA System S.A.
+// 
+// Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+// This file is part of DEHEASysML
+// 
+// The DEHEASysML is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// 
+// The DEHEASysML is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPCommon.Services.AdapterVersionService
+{
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    /// This service take care of Registering the correct Adapter Version 
+    /// </summary>
+    public class AdapterVersionService : IAdapterVersionService
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdapterVersionService" /> class.
+        /// </summary>
+        public AdapterVersionService()
+        {
+            this.CurrentAdapterVersion = Assembly.GetEntryAssembly()?.GetName().Version;
+        }
+
+        /// <summary>
+        /// Gets or sets the Current Version of the Adapter
+        /// </summary>
+        public Version CurrentAdapterVersion { get; set; }
+    }
+}

--- a/DEHPCommon/Services/AdapterVersionService/IAdapterVersionService.cs
+++ b/DEHPCommon/Services/AdapterVersionService/IAdapterVersionService.cs
@@ -1,0 +1,39 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IAdapterVersionService.cs" company="RHEA System S.A.">
+// Copyright (c) 2020-2022 RHEA System S.A.
+// 
+// Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+// This file is part of DEHEASysML
+// 
+// The DEHEASysML is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// 
+// The DEHEASysML is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPCommon.Services.AdapterVersionService
+{
+    using System;
+
+    /// <summary>
+    /// Interface definition for <see cref="AdapterVersionService"/>
+    /// </summary>
+    public interface IAdapterVersionService
+    {
+        /// <summary>
+        /// Gets or sets the Current Version of the Adapter
+        /// </summary>
+        Version CurrentAdapterVersion { get; set; }
+    }
+}

--- a/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
+++ b/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
@@ -39,6 +39,7 @@ namespace DEHPCommon.Services.ExchangeHistory
     using CDP4Common.SiteDirectoryData;
 
     using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.Services.AdapterVersionService;
     using DEHPCommon.UserInterfaces.ViewModels.ExchangeHistory;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
     
@@ -74,6 +75,11 @@ namespace DEHPCommon.Services.ExchangeHistory
         private readonly IStatusBarControlViewModel statusBar;
 
         /// <summary>
+        /// The <see cref="IAdapterVersionService"/>
+        /// </summary>
+        private readonly IAdapterVersionService adapterVersionService;
+
+        /// <summary>
         /// Gets the collection of entries
         /// </summary>
         public List<ExchangeHistoryEntryViewModel> PendingEntries { get; } = new List<ExchangeHistoryEntryViewModel>();
@@ -82,11 +88,14 @@ namespace DEHPCommon.Services.ExchangeHistory
         /// Initializes a new <see cref="ExchangeHistoryService"/>
         /// <param name="hubController">The <see cref="IHubController"/></param>
         /// <param name="statusBar">The <see cref="IStatusBarControlViewModel"/></param>
+        /// <param name="adapterVersionService">The <see cref="IAdapterVersionService"/></param>
         /// </summary>
-        public ExchangeHistoryService(IHubController hubController, IStatusBarControlViewModel statusBar)
+        public ExchangeHistoryService(IHubController hubController, IStatusBarControlViewModel statusBar,
+            IAdapterVersionService adapterVersionService)
         {
             this.hubController = hubController;
             this.statusBar = statusBar;
+            this.adapterVersionService = adapterVersionService;
         }
 
         /// <summary>
@@ -197,7 +206,7 @@ namespace DEHPCommon.Services.ExchangeHistory
 
                 var timestamp = DateTime.Now;
                 this.PendingEntries.ForEach(x => x.Timestamp = timestamp);
-                this.PendingEntries.ForEach(x => x.AdapterVersion = Assembly.GetEntryAssembly()?.GetName().Version);
+                this.PendingEntries.ForEach(x => x.AdapterVersion = this.adapterVersionService.CurrentAdapterVersion);
 
                 var entries = this.Read() ?? new List<ExchangeHistoryEntryViewModel>();
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-Common/pulls) open
- [x] I have verified that I am following theDEHP-Common [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-Common/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes RHEAGROUP/DEH-EASYSML#33

- The Adapter Version Service allow to set the current version if an adapter is a Plugin (The GetEntryAssembly is null in that case)
<!-- Thanks for contributing to DEHP-Common! -->