### PR TITLE
Difference of two ValueArray fixed : fixes #76

### DIFF
--- a/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
+++ b/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
@@ -185,6 +185,7 @@ namespace DEHPCommon.Tests.Services
             Assert.IsTrue(this.service.PendingEntries.LastOrDefault()?.Message.Contains(parameterOverride.ModelCode()));
             Assert.DoesNotThrow(() => this.service.Append(parameterOverride.ValueSet.First(), parameterOverrideclone.ValueSet.First(), ParameterSwitchKind.MANUAL));
             Assert.DoesNotThrow(() => this.service.Append(parameterOverride.ValueSet.First(), parameterOverrideclone.ValueSet.First(), ParameterSwitchKind.REFERENCE));
+            Assert.Throws<ArgumentOutOfRangeException>(() => this.service.Append(parameterOverride.ValueSet.First(), parameterOverrideclone.ValueSet.First(), (ParameterSwitchKind)10));
         }
 
         [Test]

--- a/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
+++ b/DEHPCommon.Tests/Services/ExchangeHistoryServiceTestFixture.cs
@@ -183,6 +183,8 @@ namespace DEHPCommon.Tests.Services
 
             Assert.DoesNotThrow(() => this.service.Append(parameterOverride.ValueSet.First(), parameterOverrideclone.ValueSet.First()));
             Assert.IsTrue(this.service.PendingEntries.LastOrDefault()?.Message.Contains(parameterOverride.ModelCode()));
+            Assert.DoesNotThrow(() => this.service.Append(parameterOverride.ValueSet.First(), parameterOverrideclone.ValueSet.First(), ParameterSwitchKind.MANUAL));
+            Assert.DoesNotThrow(() => this.service.Append(parameterOverride.ValueSet.First(), parameterOverrideclone.ValueSet.First(), ParameterSwitchKind.REFERENCE));
         }
 
         [Test]

--- a/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
+++ b/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
@@ -190,7 +190,6 @@ namespace DEHPCommon.Services.ExchangeHistory
                 ParameterSwitchKind.COMPUTED => valueSet.Computed,
                 ParameterSwitchKind.MANUAL => valueSet.Manual,
                 ParameterSwitchKind.REFERENCE => valueSet.Reference,
-                _ => null
             };
 
             if (parameter.ParameterType is SampledFunctionParameterType)

--- a/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
+++ b/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
@@ -42,6 +42,8 @@ namespace DEHPCommon.Services.ExchangeHistory
     using DEHPCommon.UserInterfaces.ViewModels.ExchangeHistory;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
+    using DevExpress.CodeParser;
+
     using Newtonsoft.Json;
 
     using NLog;
@@ -190,6 +192,7 @@ namespace DEHPCommon.Services.ExchangeHistory
                 ParameterSwitchKind.COMPUTED => valueSet.Computed,
                 ParameterSwitchKind.MANUAL => valueSet.Manual,
                 ParameterSwitchKind.REFERENCE => valueSet.Reference,
+                _ => throw new ArgumentOutOfRangeException(nameof(switchKind), "The ParameterSwitchKind can not be null")
             };
 
             if (parameter.ParameterType is SampledFunctionParameterType)

--- a/DEHPCommon/Services/ExchangeHistory/IExchangeHistoryService.cs
+++ b/DEHPCommon/Services/ExchangeHistory/IExchangeHistoryService.cs
@@ -25,7 +25,6 @@
 namespace DEHPCommon.Services.ExchangeHistory
 {
     using System.Collections.Generic;
-    using System.Threading;
     using System.Threading.Tasks;
 
     using CDP4Common;
@@ -43,13 +42,6 @@ namespace DEHPCommon.Services.ExchangeHistory
         /// Gets the collection of entries
         /// </summary>
         List<ExchangeHistoryEntryViewModel> PendingEntries { get; }
-
-        /// <summary>
-        /// Appends to the history a entry that concernes a difference between two <see cref="IValueSet"/>
-        /// </summary>
-        /// <param name="valueToUpdate">The valueToUpdate to update</param>
-        /// <param name="newValue">The <see cref="IValueSet"/> of reference</param>
-        void Append(ParameterValueSetBase valueToUpdate, IValueSet newValue);
 
         /// <summary>
         /// Append to the history an entry that relates of a <see cref="ChangeKind"/> on the <paramref name="thing"/>
@@ -87,5 +79,13 @@ namespace DEHPCommon.Services.ExchangeHistory
         /// </summary>
         /// <returns>A collection of <see cref="ExchangeHistoryEntryViewModel"/></returns>
         List<ExchangeHistoryEntryViewModel> Read();
+
+        /// <summary>
+        /// Appends to the history a entry that concernes a difference between two <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="valueToUpdate">The valueToUpdate to update</param>
+        /// <param name="newValue">The <see cref="IValueSet"/> of reference</param>
+        /// <param name="switchKind">The <see cref="ParameterSwitchKind"/> where changes are related</param>
+        void Append(ParameterValueSetBase valueToUpdate, IValueSet newValue, ParameterSwitchKind switchKind = ParameterSwitchKind.COMPUTED);
     }
 }

--- a/DEHPCommon/Services/ExchangeHistory/IExchangeHistoryService.cs
+++ b/DEHPCommon/Services/ExchangeHistory/IExchangeHistoryService.cs
@@ -44,6 +44,14 @@ namespace DEHPCommon.Services.ExchangeHistory
         List<ExchangeHistoryEntryViewModel> PendingEntries { get; }
 
         /// <summary>
+        /// Appends to the history a entry that concernes a difference between two <see cref="IValueSet"/>
+        /// </summary>
+        /// <param name="valueToUpdate">The valueToUpdate to update</param>
+        /// <param name="newValue">The <see cref="IValueSet"/> of reference</param>
+        /// <param name="switchKind">The <see cref="ParameterSwitchKind"/> where changes are related</param>
+        void Append(ParameterValueSetBase valueToUpdate, IValueSet newValue, ParameterSwitchKind switchKind = ParameterSwitchKind.COMPUTED);
+
+        /// <summary>
         /// Append to the history an entry that relates of a <see cref="ChangeKind"/> on the <paramref name="thing"/>
         /// </summary>
         /// <param name="thing">The <see cref="Thing"/></param>
@@ -79,13 +87,5 @@ namespace DEHPCommon.Services.ExchangeHistory
         /// </summary>
         /// <returns>A collection of <see cref="ExchangeHistoryEntryViewModel"/></returns>
         List<ExchangeHistoryEntryViewModel> Read();
-
-        /// <summary>
-        /// Appends to the history a entry that concernes a difference between two <see cref="IValueSet"/>
-        /// </summary>
-        /// <param name="valueToUpdate">The valueToUpdate to update</param>
-        /// <param name="newValue">The <see cref="IValueSet"/> of reference</param>
-        /// <param name="switchKind">The <see cref="ParameterSwitchKind"/> where changes are related</param>
-        void Append(ParameterValueSetBase valueToUpdate, IValueSet newValue, ParameterSwitchKind switchKind = ParameterSwitchKind.COMPUTED);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-Common/pulls) open
- [x] I have verified that I am following theDEHP-Common [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-Common/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixed #76 

It is possible to specify the ParameterSwitchKind reference to be able to visualize the difference in the ExchangeHistory for Manual and Reference ParameterSwitchKind. 
As the parameter of the function has a default value, no change has to be made for other adapters (Computed). 
<!-- Thanks for contributing to DEHP-Common! -->