### PR TITLE
HubSessionControlEvent added : Fixes #78

### DIFF
--- a/DEHPCommon.Tests/UserInterfaces/ViewModels/HubSessionControlViewModelTestFixture.cs
+++ b/DEHPCommon.Tests/UserInterfaces/ViewModels/HubSessionControlViewModelTestFixture.cs
@@ -26,10 +26,7 @@ using NUnit.Framework;
 
 namespace DEHPCommon.Tests.UserInterfaces.ViewModels
 {
-    using System;
-    using System.CodeDom;
     using System.Reactive.Concurrency;
-    using System.Threading;
     using System.Threading.Tasks;
 
     using CDP4Common.EngineeringModelData;

--- a/DEHPCommon/Events/HubSessionControlEvent.cs
+++ b/DEHPCommon/Events/HubSessionControlEvent.cs
@@ -1,0 +1,35 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="HubSessionControlEvent.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2022 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHP Common Library
+// 
+//    The DEHPCommon is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPCommon is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPCommon.Events
+{
+    using CDP4Dal;
+
+    /// <summary>
+    /// An event for the <see cref="CDPMessageBus"/>
+    /// </summary>
+    public class HubSessionControlEvent
+    {
+    }
+}

--- a/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
+++ b/DEHPCommon/Services/ExchangeHistory/ExchangeHistoryService.cs
@@ -42,8 +42,6 @@ namespace DEHPCommon.Services.ExchangeHistory
     using DEHPCommon.UserInterfaces.ViewModels.ExchangeHistory;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
-    using DevExpress.CodeParser;
-
     using Newtonsoft.Json;
 
     using NLog;

--- a/DEHPCommon/UserInterfaces/ViewModels/HubSessionControlViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/HubSessionControlViewModel.cs
@@ -33,6 +33,7 @@ namespace DEHPCommon.UserInterfaces.ViewModels
     using CDP4Dal;
 
     using DEHPCommon.Enumerators;
+    using DEHPCommon.Events;
     using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
@@ -174,6 +175,7 @@ namespace DEHPCommon.UserInterfaces.ViewModels
             try
             {
                 await this.hubController.Refresh();
+                CDPMessageBus.Current.SendMessage(new HubSessionControlEvent());
 
                 if (!silent)
                 {
@@ -196,6 +198,7 @@ namespace DEHPCommon.UserInterfaces.ViewModels
             {
                 await this.hubController.Reload();
                 this.statusBar.Append($"Hub session has been reloaded");
+                CDPMessageBus.Current.SendMessage(new HubSessionControlEvent());
             }
             catch (Exception e)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-Common/pulls) open
- [x] I have verified that I am following theDEHP-Common [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-Common/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #78 

HubSessionControlEvent is now sent on Refresh/Reload Command from the HubSessionControlViewModel
<!-- Thanks for contributing to DEHP-Common! -->