### PR TITLE
ParameterValueSwitch readonly and userpref file shared : Fix #80 #72

### DIFF
--- a/DEHPCommon.Tests/UserInterfaces/ViewModels/LoginViewModelTestFixture.cs
+++ b/DEHPCommon.Tests/UserInterfaces/ViewModels/LoginViewModelTestFixture.cs
@@ -130,6 +130,21 @@ namespace DEHPCommon.Tests.UserInterfaces.ViewModels
                     { 
                         Name = "test2", IterationSetup = { new IterationSetup(Guid.NewGuid(), null, null)},
                         Participant = { this.participant }
+                    },
+                    new EngineeringModelSetup(Guid.NewGuid(), null, null)
+                    {
+                        Name = "test2", IterationSetup = { new IterationSetup(Guid.NewGuid(), null, null)},
+                        Participant = 
+                        { 
+                            new Participant()
+                            {
+                                Domain = { this.domain },
+                                Person = new Person()
+                                {
+                                    Iid = Guid.NewGuid()
+                                }
+                            }
+                        }
                     }
                 });
 

--- a/DEHPCommon.Tests/UserPreferenceHandler/UserPreferenceServiceTestFixture.cs
+++ b/DEHPCommon.Tests/UserPreferenceHandler/UserPreferenceServiceTestFixture.cs
@@ -52,7 +52,7 @@ namespace DEHPCommon.Tests.UserPreferenceHandler
             this.expectedUserPreferencePath =
                 Path.Combine(this.userPreferenceService.UserPreferenceDirectories);
 
-            const string fileName = $"{UserPreferenceService<UserPreference>.FILE_NAME}{UserPreferenceService<UserPreference>.SETTING_FILE_EXTENSION}";
+            var fileName = $"{UserPreferenceService<UserPreference>.FILE_NAME}{UserPreferenceService<UserPreference>.SETTING_FILE_EXTENSION}";
 
             this.expectedUserPreferencePath = Path.Combine(this.expectedUserPreferencePath, $"{fileName}");
 

--- a/DEHPCommon.Tests/UserPreferenceHandler/UserPreferenceServiceTestFixture.cs
+++ b/DEHPCommon.Tests/UserPreferenceHandler/UserPreferenceServiceTestFixture.cs
@@ -47,13 +47,14 @@ namespace DEHPCommon.Tests.UserPreferenceHandler
         [SetUp]
         public void SetUp()
         {
-            this.expectedUserPreferencePath =
-                Path.Combine(
-                    UserPreferenceService<UserPreference>.ApplicationExecutePath,
-                    UserPreferenceService<UserPreference>.UserPreferenceDirectoryName,
-                    "DEHPCommon.settings.json");
-
             this.userPreferenceService = new UserPreferenceService<UserPreference>();
+
+            this.expectedUserPreferencePath =
+                Path.Combine(this.userPreferenceService.UserPreferenceDirectories);
+
+            const string fileName = $"{UserPreferenceService<UserPreference>.FILE_NAME}{UserPreferenceService<UserPreference>.SETTING_FILE_EXTENSION}";
+
+            this.expectedUserPreferencePath = Path.Combine(this.expectedUserPreferencePath, $"{fileName}");
 
             this.serverConnection1 = new ServerConnection()
             {
@@ -149,8 +150,13 @@ namespace DEHPCommon.Tests.UserPreferenceHandler
         [Test]
         public void VerifyCheckConfigurationDirectory()
         {
-            var configurationDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "UserPreferenceService");
-            Directory.Delete(configurationDirectory, true);
+            var configurationDirectory = Path.Combine(this.userPreferenceService.UserPreferenceDirectories);
+
+            if (Directory.Exists(configurationDirectory))
+            {
+                Directory.Delete(configurationDirectory, true);
+            }
+
             Assert.IsFalse(Directory.Exists(configurationDirectory));
             this.userPreferenceService.CheckConfigurationDirectory();
             Assert.IsTrue(Directory.Exists(configurationDirectory));

--- a/DEHPCommon/UserInterfaces/ViewModels/LoginViewModel.cs
+++ b/DEHPCommon/UserInterfaces/ViewModels/LoginViewModel.cs
@@ -414,9 +414,9 @@ namespace DEHPCommon.UserInterfaces.ViewModels
         {
             this.DomainsOfExpertise.Clear();
 
-            var activeParticipant = this.SelectedEngineeringModel.Thing.Participant.Single(x => x.Person == this.hubController.Session.ActivePerson);
+            var activeParticipant = this.SelectedEngineeringModel.Thing.Participant.SingleOrDefault(x => x.Person == this.hubController.Session.ActivePerson);
 
-            if (activeParticipant.Domain.Count != 0)
+            if (activeParticipant != null && activeParticipant.Domain.Count != 0)
             {
                 foreach (var vm in activeParticipant.Domain.OrderBy(x => x.Name).Select(x => new DomainOfExpertiseRowViewModel(x)))
                 {
@@ -449,7 +449,9 @@ namespace DEHPCommon.UserInterfaces.ViewModels
         {
             this.EngineeringModels.Clear();
 
-            foreach (var em in this.hubController.GetEngineeringModels().OrderBy(m => m.Name))
+            foreach (var em in this.hubController.GetEngineeringModels()
+                         .Where(x => x.Participant.Any(participant => 
+                             participant.Person.Iid == this.hubController.Session.ActivePerson.Iid)).OrderBy(m => m.Name))
             {
                 this.EngineeringModels.Add(new EngineeringModelRowViewModel(em));
             }

--- a/DEHPCommon/UserInterfaces/Views/ObjectBrowser/ObjectBrowser.xaml
+++ b/DEHPCommon/UserInterfaces/Views/ObjectBrowser/ObjectBrowser.xaml
@@ -3,11 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
-             xmlns:dynamic="clr-namespace:System.Dynamic;assembly=System.Core"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
-             xmlns:engineeringModelData="clr-namespace:CDP4Common.EngineeringModelData;assembly=CDP4Common"
              xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
              xmlns:viewModels="clr-namespace:DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows"
              xmlns:converters="clr-namespace:DEHPCommon.Converters"
@@ -180,20 +178,7 @@
                     <dxg:TreeListColumn FieldName="OwnerShortName" Header="Owner"  Width="45"/>
                     <dxg:TreeListColumn FieldName="Published" Header="Published Value"/>
                     <dxg:TreeListColumn FieldName="ScaleShortName" Header="Scale"/>
-                    <dxg:TreeListColumn AllowEditing="True" FieldName="Switch">
-                        <dxg:TreeListColumn.CellTemplate>
-                            <DataTemplate>
-                                <dxe:ComboBoxEdit Name="PART_Editor"
-                                                  IsTextEditable="False"
-                                                  ShowBorder="True"
-                                                  ShowCustomItems="False">
-                                    <dxmvvm:Interaction.Behaviors>
-                                        <dxmvvm:EnumItemsSourceBehavior EnumType="{x:Type engineeringModelData:ParameterSwitchKind}" />
-                                    </dxmvvm:Interaction.Behaviors>
-                                </dxe:ComboBoxEdit>
-                            </DataTemplate>
-                        </dxg:TreeListColumn.CellTemplate>
-                    </dxg:TreeListColumn>
+                    <dxg:TreeListColumn AllowEditing="False" FieldName="Switch"/>
                     <dxg:TreeListColumn FieldName="Computed" />
                     <dxg:TreeListColumn AllowEditing="False" FieldName="Manual" />
                     <dxg:TreeListColumn AllowEditing="False" FieldName="Reference" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-Common/pulls) open
- [x] I have verified that I am following theDEHP-Common [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-Common/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #80 #72 #71 

- In the ObjectBrowserTree, the ParameterValueSwitch is readonly now
- The UserPreference Json file is shared by all adapters, including Java ones
- Only EMs where the person is Participant filter
<!-- Thanks for contributing to DEHP-Common! -->